### PR TITLE
Target lists and parser code cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,16 @@ sudo arpfox -i wlan0 -t 10.0.0.25 10.0.0.1
 ...
 ```
 
+## Target Specification
+
+`arpfox` takes targets in the same format as `nmap`. The following are all valid target specifications:
+
+* `10.0.0.1`
+* `10.0.0.0/24`
+* `10.0.0.*`
+* `10.0.0.1-10`
+* `10.0.0.1, 10.0.0.5-10, 192.168.1.*, 192.168.10.0/24`
+
 ## A practical example
 
 Alice is a security researcher, and she's going to redirect and watch traffic
@@ -64,7 +74,7 @@ something like:
 
 ```
 # OSX
-sudo sysctl -w net.ipv4.ip_forward=1
+sudo sysctl net.inet.ip.forwarding=1
 
 # FreeBSD
 sudo sysctl -w net.inet.ip.forwarding=1

--- a/arp/arp.go
+++ b/arp/arp.go
@@ -2,6 +2,7 @@
 package arp
 
 import (
+	"encoding/binary"
 	"net"
 	"sync"
 
@@ -10,7 +11,7 @@ import (
 )
 
 var (
-	table   map[string]net.HardwareAddr
+	table   map[uint32]net.HardwareAddr
 	tableMu sync.RWMutex
 )
 
@@ -20,25 +21,25 @@ var defaultSerializeOpts = gopacket.SerializeOptions{
 }
 
 func init() {
-	table = make(map[string]net.HardwareAddr)
+	table = make(map[uint32]net.HardwareAddr)
 }
 
 // Add adds a IP-MAC map to a runtime ARP table.
 func Add(ip net.IP, hwaddr net.HardwareAddr) {
 	tableMu.Lock()
 	defer tableMu.Unlock()
-	table[ip.To4().String()] = hwaddr
+	table[binary.BigEndian.Uint32(ip)] = hwaddr
 }
 
 // Delete removes an IP from the runtime ARP table.
 func Delete(ip net.IP) {
 	tableMu.Lock()
 	defer tableMu.Unlock()
-	delete(table, ip.To4().String())
+	delete(table, binary.BigEndian.Uint32(ip))
 }
 
 // List returns the current runtime ARP table.
-func List() map[string]net.HardwareAddr {
+func List() map[uint32]net.HardwareAddr {
 	tableMu.RLock()
 	defer tableMu.RUnlock()
 	return table
@@ -53,14 +54,16 @@ type Address struct {
 
 // Lookup returns the Address given an IP, if the IP is not found within the
 // table, a lookup is attempted.
-func Lookup(ip string) (*Address, error) {
+func Lookup(ip uint32) (*Address, error) {
+	var b []byte
+	binary.BigEndian.PutUint32(b, ip)
 	if hwaddr, ok := table[ip]; ok {
 		return &Address{
-			IP:           net.ParseIP(ip),
+			IP:           net.IP(b),
 			HardwareAddr: hwaddr,
 		}, nil
 	}
-	return doARPLookup(ip)
+	return doARPLookup(net.IP(b).To4().String())
 }
 
 // NewARPRequest creates a bew ARP packet of type "request.

--- a/arp/arp.go
+++ b/arp/arp.go
@@ -55,7 +55,7 @@ type Address struct {
 // Lookup returns the Address given an IP, if the IP is not found within the
 // table, a lookup is attempted.
 func Lookup(ip uint32) (*Address, error) {
-	var b []byte
+	b := make([]byte, 4)
 	binary.BigEndian.PutUint32(b, ip)
 	if hwaddr, ok := table[ip]; ok {
 		return &Address{

--- a/arp/arp_test.go
+++ b/arp/arp_test.go
@@ -1,11 +1,14 @@
 package arp
 
 import (
+	"encoding/binary"
+	"net"
 	"testing"
 )
 
 func TestArp(t *testing.T) {
-	addr, err := Lookup("10.0.0.1")
+	ip := net.IP{10, 0, 0, 1}
+	addr, err := Lookup(binary.BigEndian.Uint32(ip))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/iprange/funcs.go
+++ b/iprange/funcs.go
@@ -62,19 +62,19 @@ func streamRange(lower, upper net.IP) chan net.IP {
 }
 
 // Expand expands an address with a mask taken from a stream
-func Expand(c chan net.IP) []net.IP {
+func (r *AddressRange) Expand() []net.IP {
 	ips := []net.IP{}
-	for ip := range c {
+	for ip := range streamRange(r.Min, r.Max) {
 		ips = append(ips, ip)
 	}
 	return ips
 }
 
-// ExpandAll expands and normalizes a set of parsed target specifications
-func ExpandAll(r Result) []net.IP {
+// Expand expands and normalizes a set of parsed target specifications
+func (l AddressRangeList) Expand() []net.IP {
 	var res []net.IP
-	for i := range r {
-		res = append(res, Expand(New(&r[i]))...)
+	for i := range l {
+		res = append(res, l[i].Expand()...)
 	}
 	return normalize(res)
 }
@@ -89,9 +89,4 @@ func normalize(src []net.IP) []net.IP {
 		}
 	}
 	return dst
-}
-
-// New creates a stream of addresses with masks from a target specification
-func New(addressRange *Address) chan net.IP {
-	return streamRange(addressRange.Min, addressRange.Max)
 }

--- a/iprange/funcs.go
+++ b/iprange/funcs.go
@@ -68,6 +68,14 @@ func Expand(c chan net.IP) []net.IP {
 	return ips
 }
 
+func ExpandAll(r Result) (out []net.IP) {
+	// TODO: Add code to normalize final array
+	for i := range r {
+		out = append(out, Expand(New(&r[i]))...)
+	}
+	return
+}
+
 func New(addressRange *Address) chan net.IP {
 	return streamRange(addressRange.Min, addressRange.Max)
 }

--- a/iprange/funcs.go
+++ b/iprange/funcs.go
@@ -80,7 +80,7 @@ func (l AddressRangeList) Expand() []net.IP {
 }
 
 func normalize(src []net.IP) []net.IP {
-	sort.Sort(Asc(src))
+	sort.Sort(asc(src))
 	dst := make([]net.IP, 1, len(src))
 	dst[0] = src[0]
 	for i := range src {

--- a/iprange/ip.y
+++ b/iprange/ip.y
@@ -30,7 +30,7 @@ type octetRange struct {
     result      AddressRangeList
 }
 
-%token  <num> NUM
+%token  <num> num
 %type   <addrRange> address target
 %type   <octRange>  term octet_range
 %type   <result>    result
@@ -50,7 +50,7 @@ result: target
 
 comma: ',' | ',' ' '
 
-target:     address '/' NUM
+target:     address '/' num
                 {
                     mask := net.CIDRMask(int($3), 32)
                     min := $1.Min.Mask(mask)
@@ -79,11 +79,11 @@ address:    term '.' term '.' term '.' term
                     }
                 }
 
-term:   NUM         { $$ = octetRange { $1, $1 } }
+term:   num         { $$ = octetRange { $1, $1 } }
     |   '*'         { $$ = octetRange { 0, 255 } }
     |   octet_range { $$ = $1 }
 
-octet_range:    NUM '-' NUM { $$ = octetRange { $1, $3 } }
+octet_range:    num '-' num { $$ = octetRange { $1, $3 } }
 
 %%
 

--- a/iprange/ip.y
+++ b/iprange/ip.y
@@ -3,15 +3,13 @@
 package iprange
 
 import (
-    "bytes"
     "encoding/binary"
-    "log"
     "net"
-    "strconv"
-    "unicode/utf8"
 
     "github.com/pkg/errors"
 )
+
+type Result []Address
 
 type Address struct {
     Min net.IP
@@ -29,14 +27,28 @@ type octetRange struct {
     num         byte
     octRange    octetRange
     addrRange   Address
+    result      Result
 }
 
 %token  <num> NUM
-%token  <num>  MASK
 %type   <addrRange> address target
-%type   <octRange>   term octet_range
+%type   <octRange>  term octet_range
+%type   <result>    result
 
 %%
+
+result: target
+            {
+                $$ = append($$, $1)
+                iplex.(*ipLex).output = $$
+            }
+      | result comma target
+            {
+                $$ = append($1, $3)
+                iplex.(*ipLex).output = $$
+            }
+
+comma: ',' | ',' ' '
 
 target:     address '/' NUM
                 {
@@ -53,12 +65,10 @@ target:     address '/' NUM
                         Min: min.To4(),
                         Max: max.To4(),
                     }
-                    iplex.(*ipLex).output = $$
                 }
       |     address
                 {
                     $$ = $1
-                    iplex.(*ipLex).output = $$
                 }
 
 address:    term '.' term '.' term '.' term
@@ -69,7 +79,7 @@ address:    term '.' term '.' term '.' term
                     }
                 }
 
-term:   NUM       { $$ = octetRange { $1, $1 } }
+term:   NUM         { $$ = octetRange { $1, $1 } }
     |   '*'         { $$ = octetRange { 0, 255 } }
     |   octet_range { $$ = $1 }
 
@@ -77,87 +87,11 @@ octet_range:    NUM '-' NUM { $$ = octetRange { $1, $3 } }
 
 %%
 
-const eof = 0
-
-type ipLex struct {
-    line    []byte
-    peek    rune
-    output  Address
-    err     error
-}
-
-func (ip *ipLex) Lex(yylval *ipSymType) int {
-    for {
-        c := ip.next()
-        switch c {
-        case eof:
-            return eof
-        case '.', '-', '/', '*':
-            return int(c)
-        case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
-            return ip.byte(c, yylval)
-        case ' ', '\t', '\n', '\r':
-        default:
-        }
-    }
-}
-
-func (ip *ipLex) byte(c rune, yylval *ipSymType) int {
-    add := func(b *bytes.Buffer, c rune) {
-        if _, err := b.WriteRune(c); err != nil {
-            log.Fatalf("WriteRune: %s", err)
-        }
-    }
-    var b bytes.Buffer
-    add(&b, c)
-    L: for {
-        c = ip.next()
-        switch c {
-        case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
-            add(&b, c)
-        default:
-            break L
-        }
-    }
-    if c != eof {
-        ip.peek = c
-    }
-    octet, err := strconv.ParseUint(b.String(), 10, 32)
-    if err != nil {
-        log.Printf("badly formatted octet")
-        return eof
-    }
-    yylval.num = byte(octet)
-    return NUM
-}
-
-func (ip *ipLex) next() rune {
-    if ip.peek != eof {
-        r := ip.peek
-        ip.peek = eof
-        return r
-    }
-    if len(ip.line) == 0 {
-        return eof
-    }
-    c, size := utf8.DecodeRune(ip.line)
-    ip.line = ip.line[size:]
-    if c == utf8.RuneError && size == 1 {
-        log.Print("invalid utf8")
-        return ip.next()
-    }
-    return c
-}
-
-func (ip *ipLex) Error(s string) {
-    ip.err = errors.New(s)
-}
-
-func Parse(in string) (*Address, error) {
+func Parse(in string) (Result, error) {
     lex := &ipLex{line: []byte(in)}
     errCode := ipParse(lex)
     if errCode != 0 || lex.err != nil {
         return nil, errors.Wrap(lex.err, "could not parse target")
     }
-    return &lex.output, nil
+    return lex.output, nil
 }

--- a/iprange/iprange_test.go
+++ b/iprange/iprange_test.go
@@ -10,31 +10,28 @@ import (
 func TestSimpleAddress(t *testing.T) {
 	ipRange, err := Parse("192.168.1.1")
 	assert.Nil(t, err)
-	assert.Len(t, ipRange, 1)
 
-	assert.Equal(t, net.IPv4(192, 168, 1, 1).To4(), ipRange[0].Min)
-	assert.Equal(t, ipRange[0].Min, ipRange[0].Max)
+	assert.Equal(t, net.IPv4(192, 168, 1, 1).To4(), ipRange.Min)
+	assert.Equal(t, ipRange.Min, ipRange.Max)
 }
 
 func TestCIDRAddress(t *testing.T) {
 	{
 		ipRange, err := Parse("192.168.1.1/24")
 		assert.Nil(t, err)
-		assert.Len(t, ipRange, 1)
 
-		assert.Equal(t, net.IPv4(192, 168, 1, 0).To4(), ipRange[0].Min)
-		assert.Equal(t, net.IPv4(192, 168, 1, 255).To4(), ipRange[0].Max)
+		assert.Equal(t, net.IPv4(192, 168, 1, 0).To4(), ipRange.Min)
+		assert.Equal(t, net.IPv4(192, 168, 1, 255).To4(), ipRange.Max)
 	}
 
 	{
 		ipRange, err := Parse("192.168.2.1/24")
 		assert.Nil(t, err)
-		assert.Len(t, ipRange, 1)
 
-		assert.Equal(t, net.IPv4(192, 168, 2, 0).To4(), ipRange[0].Min)
-		assert.Equal(t, net.IPv4(192, 168, 2, 255).To4(), ipRange[0].Max)
+		assert.Equal(t, net.IPv4(192, 168, 2, 0).To4(), ipRange.Min)
+		assert.Equal(t, net.IPv4(192, 168, 2, 255).To4(), ipRange.Max)
 
-		out := Expand(New(&ipRange[0]))
+		out := ipRange.Expand()
 		assert.Equal(t, int(0xffffffff-0xffffff00), len(out)-1)
 		for i := 0; i < 256; i++ {
 			assert.Equal(t, net.IP([]byte{192, 168, 2, byte(i)}), out[i])
@@ -44,12 +41,11 @@ func TestCIDRAddress(t *testing.T) {
 	{
 		ipRange, err := Parse("10.1.2.3/16")
 		assert.Nil(t, err)
-		assert.Len(t, ipRange, 1)
 
-		assert.Equal(t, net.IPv4(10, 1, 0, 0).To4(), ipRange[0].Min)
-		assert.Equal(t, net.IPv4(10, 1, 255, 255).To4(), ipRange[0].Max)
+		assert.Equal(t, net.IPv4(10, 1, 0, 0).To4(), ipRange.Min)
+		assert.Equal(t, net.IPv4(10, 1, 255, 255).To4(), ipRange.Max)
 
-		out := Expand(New(&ipRange[0]))
+		out := ipRange.Expand()
 		assert.Equal(t, int(0xffffffff-0xffff0000), len(out)-1)
 		for i := 0; i < 65536; i++ {
 			assert.Equal(t, net.IP([]byte{10, 1, byte(i / 256), byte(i % 256)}), out[i])
@@ -59,59 +55,53 @@ func TestCIDRAddress(t *testing.T) {
 	{
 		ipRange, err := Parse("10.1.2.3/32")
 		assert.Nil(t, err)
-		assert.Len(t, ipRange, 1)
 
-		assert.Equal(t, net.IPv4(10, 1, 2, 3).To4(), ipRange[0].Min)
-		assert.Equal(t, ipRange[0].Min, ipRange[0].Max)
+		assert.Equal(t, net.IPv4(10, 1, 2, 3).To4(), ipRange.Min)
+		assert.Equal(t, ipRange.Min, ipRange.Max)
 	}
 }
 
 func TestWildcardAddress(t *testing.T) {
 	ipRange, err := Parse("192.168.1.*")
 	assert.Nil(t, err)
-	assert.Len(t, ipRange, 1)
 
-	assert.Equal(t, net.IPv4(192, 168, 1, 0).To4(), ipRange[0].Min)
-	assert.Equal(t, net.IPv4(192, 168, 1, 255).To4(), ipRange[0].Max)
+	assert.Equal(t, net.IPv4(192, 168, 1, 0).To4(), ipRange.Min)
+	assert.Equal(t, net.IPv4(192, 168, 1, 255).To4(), ipRange.Max)
 }
 
 func TestRangeAddress(t *testing.T) {
 	{
 		ipRange, err := Parse("192.168.1.10-20")
 		assert.Nil(t, err)
-		assert.Len(t, ipRange, 1)
 
-		assert.Equal(t, net.IPv4(192, 168, 1, 10).To4(), ipRange[0].Min)
-		assert.Equal(t, net.IPv4(192, 168, 1, 20).To4(), ipRange[0].Max)
+		assert.Equal(t, net.IPv4(192, 168, 1, 10).To4(), ipRange.Min)
+		assert.Equal(t, net.IPv4(192, 168, 1, 20).To4(), ipRange.Max)
 	}
 
 	{
 		ipRange, err := Parse("192.168.10-20.1")
 		assert.Nil(t, err)
-		assert.Len(t, ipRange, 1)
 
-		assert.Equal(t, net.IPv4(192, 168, 10, 1).To4(), ipRange[0].Min)
-		assert.Equal(t, net.IPv4(192, 168, 20, 1).To4(), ipRange[0].Max)
+		assert.Equal(t, net.IPv4(192, 168, 10, 1).To4(), ipRange.Min)
+		assert.Equal(t, net.IPv4(192, 168, 20, 1).To4(), ipRange.Max)
 	}
 
 	{
 		ipRange, err := Parse("0-255.1.1.1")
 		assert.Nil(t, err)
-		assert.Len(t, ipRange, 1)
 
-		assert.Equal(t, net.IPv4(0, 1, 1, 1).To4(), ipRange[0].Min)
-		assert.Equal(t, net.IPv4(255, 1, 1, 1).To4(), ipRange[0].Max)
+		assert.Equal(t, net.IPv4(0, 1, 1, 1).To4(), ipRange.Min)
+		assert.Equal(t, net.IPv4(255, 1, 1, 1).To4(), ipRange.Max)
 	}
 
 	{
 		ipRange, err := Parse("1-2.3-4.5-6.7-8")
 		assert.Nil(t, err)
-		assert.Len(t, ipRange, 1)
 
-		assert.Equal(t, net.IPv4(1, 3, 5, 7).To4(), ipRange[0].Min)
-		assert.Equal(t, net.IPv4(2, 4, 6, 8).To4(), ipRange[0].Max)
+		assert.Equal(t, net.IPv4(1, 3, 5, 7).To4(), ipRange.Min)
+		assert.Equal(t, net.IPv4(2, 4, 6, 8).To4(), ipRange.Max)
 
-		out := Expand(New(&ipRange[0]))
+		out := ipRange.Expand()
 
 		assert.Equal(t, 16, len(out))
 		assert.Equal(t, out, []net.IP{
@@ -138,28 +128,27 @@ func TestRangeAddress(t *testing.T) {
 func TestMixedAddress(t *testing.T) {
 	ipRange, err := Parse("192.168.10-20.*/25")
 	assert.Nil(t, err)
-	assert.Len(t, ipRange, 1)
 
-	assert.Equal(t, net.IPv4(192, 168, 10, 0).To4(), ipRange[0].Min)
-	assert.Equal(t, net.IPv4(192, 168, 10, 127).To4(), ipRange[0].Max)
+	assert.Equal(t, net.IPv4(192, 168, 10, 0).To4(), ipRange.Min)
+	assert.Equal(t, net.IPv4(192, 168, 10, 127).To4(), ipRange.Max)
 }
 
 func TestList(t *testing.T) {
-	ipRange, err := Parse("192.168.1.1, 192.168.1.1/24, 192.168.1.*, 192.168.1.10-20")
+	rangeList, err := ParseList("192.168.1.1, 192.168.1.1/24, 192.168.1.*, 192.168.1.10-20")
 	assert.Nil(t, err)
-	assert.Len(t, ipRange, 4)
+	assert.Len(t, rangeList, 4)
 
-	assert.Equal(t, net.IP([]byte{192, 168, 1, 1}), ipRange[0].Min)
-	assert.Equal(t, net.IP([]byte{192, 168, 1, 1}), ipRange[0].Max)
+	assert.Equal(t, net.IP([]byte{192, 168, 1, 1}), rangeList[0].Min)
+	assert.Equal(t, net.IP([]byte{192, 168, 1, 1}), rangeList[0].Max)
 
-	assert.Equal(t, net.IP([]byte{192, 168, 1, 0}), ipRange[1].Min)
-	assert.Equal(t, net.IP([]byte{192, 168, 1, 255}), ipRange[1].Max)
+	assert.Equal(t, net.IP([]byte{192, 168, 1, 0}), rangeList[1].Min)
+	assert.Equal(t, net.IP([]byte{192, 168, 1, 255}), rangeList[1].Max)
 
-	assert.Equal(t, net.IP([]byte{192, 168, 1, 0}), ipRange[2].Min)
-	assert.Equal(t, net.IP([]byte{192, 168, 1, 255}), ipRange[2].Max)
+	assert.Equal(t, net.IP([]byte{192, 168, 1, 0}), rangeList[2].Min)
+	assert.Equal(t, net.IP([]byte{192, 168, 1, 255}), rangeList[2].Max)
 
-	assert.Equal(t, net.IP([]byte{192, 168, 1, 10}), ipRange[3].Min)
-	assert.Equal(t, net.IP([]byte{192, 168, 1, 20}), ipRange[3].Max)
+	assert.Equal(t, net.IP([]byte{192, 168, 1, 10}), rangeList[3].Min)
+	assert.Equal(t, net.IP([]byte{192, 168, 1, 20}), rangeList[3].Max)
 }
 
 func TestBadAddress(t *testing.T) {
@@ -169,15 +158,15 @@ func TestBadAddress(t *testing.T) {
 }
 
 func TestBadList(t *testing.T) {
-	ipRange, err := Parse("192.168.1,, 192.168.1.1/24, 192.168.1.*, 192.168.1.10-20")
+	rangeList, err := ParseList("192.168.1,, 192.168.1.1/24, 192.168.1.*, 192.168.1.10-20")
 	assert.Error(t, err)
-	assert.Len(t, ipRange, 0)
+	assert.Nil(t, rangeList)
 }
 
 func TestListExpansion(t *testing.T) {
-	ipRange, err := Parse("192.168.1.10, 192.168.1.1-20, 192.168.1.10/29")
+	rangeList, err := ParseList("192.168.1.10, 192.168.1.1-20, 192.168.1.10/29")
 	assert.Nil(t, err)
 
-	expanded := ExpandAll(ipRange)
+	expanded := rangeList.Expand()
 	assert.Len(t, expanded, 20)
 }

--- a/iprange/iprange_test.go
+++ b/iprange/iprange_test.go
@@ -10,28 +10,31 @@ import (
 func TestSimpleAddress(t *testing.T) {
 	ipRange, err := Parse("192.168.1.1")
 	assert.Nil(t, err)
+	assert.Len(t, ipRange, 1)
 
-	assert.Equal(t, net.IPv4(192, 168, 1, 1).To4(), ipRange.Min)
-	assert.Equal(t, ipRange.Min, ipRange.Max)
+	assert.Equal(t, net.IPv4(192, 168, 1, 1).To4(), ipRange[0].Min)
+	assert.Equal(t, ipRange[0].Min, ipRange[0].Max)
 }
 
 func TestCIDRAddress(t *testing.T) {
 	{
 		ipRange, err := Parse("192.168.1.1/24")
 		assert.Nil(t, err)
+		assert.Len(t, ipRange, 1)
 
-		assert.Equal(t, net.IPv4(192, 168, 1, 0).To4(), ipRange.Min)
-		assert.Equal(t, net.IPv4(192, 168, 1, 255).To4(), ipRange.Max)
+		assert.Equal(t, net.IPv4(192, 168, 1, 0).To4(), ipRange[0].Min)
+		assert.Equal(t, net.IPv4(192, 168, 1, 255).To4(), ipRange[0].Max)
 	}
 
 	{
 		ipRange, err := Parse("192.168.2.1/24")
 		assert.Nil(t, err)
+		assert.Len(t, ipRange, 1)
 
-		assert.Equal(t, net.IPv4(192, 168, 2, 0).To4(), ipRange.Min)
-		assert.Equal(t, net.IPv4(192, 168, 2, 255).To4(), ipRange.Max)
+		assert.Equal(t, net.IPv4(192, 168, 2, 0).To4(), ipRange[0].Min)
+		assert.Equal(t, net.IPv4(192, 168, 2, 255).To4(), ipRange[0].Max)
 
-		out := Expand(New(ipRange))
+		out := Expand(New(&ipRange[0]))
 		assert.Equal(t, int(0xffffffff-0xffffff00), len(out)-1)
 		for i := 0; i < 256; i++ {
 			assert.Equal(t, net.IP([]byte{192, 168, 2, byte(i)}), out[i])
@@ -41,11 +44,12 @@ func TestCIDRAddress(t *testing.T) {
 	{
 		ipRange, err := Parse("10.1.2.3/16")
 		assert.Nil(t, err)
+		assert.Len(t, ipRange, 1)
 
-		assert.Equal(t, net.IPv4(10, 1, 0, 0).To4(), ipRange.Min)
-		assert.Equal(t, net.IPv4(10, 1, 255, 255).To4(), ipRange.Max)
+		assert.Equal(t, net.IPv4(10, 1, 0, 0).To4(), ipRange[0].Min)
+		assert.Equal(t, net.IPv4(10, 1, 255, 255).To4(), ipRange[0].Max)
 
-		out := Expand(New(ipRange))
+		out := Expand(New(&ipRange[0]))
 		assert.Equal(t, int(0xffffffff-0xffff0000), len(out)-1)
 		for i := 0; i < 65536; i++ {
 			assert.Equal(t, net.IP([]byte{10, 1, byte(i / 256), byte(i % 256)}), out[i])
@@ -55,53 +59,59 @@ func TestCIDRAddress(t *testing.T) {
 	{
 		ipRange, err := Parse("10.1.2.3/32")
 		assert.Nil(t, err)
+		assert.Len(t, ipRange, 1)
 
-		assert.Equal(t, net.IPv4(10, 1, 2, 3).To4(), ipRange.Min)
-		assert.Equal(t, ipRange.Min, ipRange.Max)
+		assert.Equal(t, net.IPv4(10, 1, 2, 3).To4(), ipRange[0].Min)
+		assert.Equal(t, ipRange[0].Min, ipRange[0].Max)
 	}
 }
 
 func TestWildcardAddress(t *testing.T) {
 	ipRange, err := Parse("192.168.1.*")
 	assert.Nil(t, err)
+	assert.Len(t, ipRange, 1)
 
-	assert.Equal(t, net.IPv4(192, 168, 1, 0).To4(), ipRange.Min)
-	assert.Equal(t, net.IPv4(192, 168, 1, 255).To4(), ipRange.Max)
+	assert.Equal(t, net.IPv4(192, 168, 1, 0).To4(), ipRange[0].Min)
+	assert.Equal(t, net.IPv4(192, 168, 1, 255).To4(), ipRange[0].Max)
 }
 
 func TestRangeAddress(t *testing.T) {
 	{
 		ipRange, err := Parse("192.168.1.10-20")
 		assert.Nil(t, err)
+		assert.Len(t, ipRange, 1)
 
-		assert.Equal(t, net.IPv4(192, 168, 1, 10).To4(), ipRange.Min)
-		assert.Equal(t, net.IPv4(192, 168, 1, 20).To4(), ipRange.Max)
+		assert.Equal(t, net.IPv4(192, 168, 1, 10).To4(), ipRange[0].Min)
+		assert.Equal(t, net.IPv4(192, 168, 1, 20).To4(), ipRange[0].Max)
 	}
 
 	{
 		ipRange, err := Parse("192.168.10-20.1")
 		assert.Nil(t, err)
+		assert.Len(t, ipRange, 1)
 
-		assert.Equal(t, net.IPv4(192, 168, 10, 1).To4(), ipRange.Min)
-		assert.Equal(t, net.IPv4(192, 168, 20, 1).To4(), ipRange.Max)
+		assert.Equal(t, net.IPv4(192, 168, 10, 1).To4(), ipRange[0].Min)
+		assert.Equal(t, net.IPv4(192, 168, 20, 1).To4(), ipRange[0].Max)
 	}
 
 	{
 		ipRange, err := Parse("0-255.1.1.1")
 		assert.Nil(t, err)
+		assert.Len(t, ipRange, 1)
 
-		assert.Equal(t, net.IPv4(0, 1, 1, 1).To4(), ipRange.Min)
-		assert.Equal(t, net.IPv4(255, 1, 1, 1).To4(), ipRange.Max)
+		assert.Equal(t, net.IPv4(0, 1, 1, 1).To4(), ipRange[0].Min)
+		assert.Equal(t, net.IPv4(255, 1, 1, 1).To4(), ipRange[0].Max)
 	}
 
 	{
 		ipRange, err := Parse("1-2.3-4.5-6.7-8")
 		assert.Nil(t, err)
+		assert.Len(t, ipRange, 1)
 
-		assert.Equal(t, net.IPv4(1, 3, 5, 7).To4(), ipRange.Min)
-		assert.Equal(t, net.IPv4(2, 4, 6, 8).To4(), ipRange.Max)
+		assert.Equal(t, net.IPv4(1, 3, 5, 7).To4(), ipRange[0].Min)
+		assert.Equal(t, net.IPv4(2, 4, 6, 8).To4(), ipRange[0].Max)
 
-		out := Expand(New(ipRange))
+		out := Expand(New(&ipRange[0]))
 
 		assert.Equal(t, 16, len(out))
 		assert.Equal(t, out, []net.IP{
@@ -128,13 +138,38 @@ func TestRangeAddress(t *testing.T) {
 func TestMixedAddress(t *testing.T) {
 	ipRange, err := Parse("192.168.10-20.*/25")
 	assert.Nil(t, err)
+	assert.Len(t, ipRange, 1)
 
-	assert.Equal(t, net.IPv4(192, 168, 10, 0).To4(), ipRange.Min)
-	assert.Equal(t, net.IPv4(192, 168, 10, 127).To4(), ipRange.Max)
+	assert.Equal(t, net.IPv4(192, 168, 10, 0).To4(), ipRange[0].Min)
+	assert.Equal(t, net.IPv4(192, 168, 10, 127).To4(), ipRange[0].Max)
+}
+
+func TestList(t *testing.T) {
+	ipRange, err := Parse("192.168.1.1, 192.168.1.1/24, 192.168.1.*, 192.168.1.10-20")
+	assert.Nil(t, err)
+	assert.Len(t, ipRange, 4)
+
+	assert.Equal(t, net.IP([]byte{192, 168, 1, 1}), ipRange[0].Min)
+	assert.Equal(t, net.IP([]byte{192, 168, 1, 1}), ipRange[0].Max)
+
+	assert.Equal(t, net.IP([]byte{192, 168, 1, 0}), ipRange[1].Min)
+	assert.Equal(t, net.IP([]byte{192, 168, 1, 255}), ipRange[1].Max)
+
+	assert.Equal(t, net.IP([]byte{192, 168, 1, 0}), ipRange[2].Min)
+	assert.Equal(t, net.IP([]byte{192, 168, 1, 255}), ipRange[2].Max)
+
+	assert.Equal(t, net.IP([]byte{192, 168, 1, 10}), ipRange[3].Min)
+	assert.Equal(t, net.IP([]byte{192, 168, 1, 20}), ipRange[3].Max)
 }
 
 func TestBadAddress(t *testing.T) {
 	ipRange, err := Parse("192.168.10")
 	assert.Nil(t, ipRange)
 	assert.Error(t, err)
+}
+
+func TestBadList(t *testing.T) {
+	ipRange, err := Parse("192.168.1,, 192.168.1.1/24, 192.168.1.*, 192.168.1.10-20")
+	assert.Error(t, err)
+	assert.Len(t, ipRange, 0)
 }

--- a/iprange/iprange_test.go
+++ b/iprange/iprange_test.go
@@ -173,3 +173,11 @@ func TestBadList(t *testing.T) {
 	assert.Error(t, err)
 	assert.Len(t, ipRange, 0)
 }
+
+func TestListExpansion(t *testing.T) {
+	ipRange, err := Parse("192.168.1.10, 192.168.1.1-20, 192.168.1.10/29")
+	assert.Nil(t, err)
+
+	expanded := ExpandAll(ipRange)
+	assert.Len(t, expanded, 20)
+}

--- a/iprange/lex.go
+++ b/iprange/lex.go
@@ -13,7 +13,7 @@ const eof = 0
 type ipLex struct {
 	line   []byte
 	peek   rune
-	output Result
+	output AddressRangeList
 	err    error
 }
 

--- a/iprange/lex.go
+++ b/iprange/lex.go
@@ -1,0 +1,84 @@
+package iprange
+
+import (
+	"bytes"
+	"errors"
+	"log"
+	"strconv"
+	"unicode/utf8"
+)
+
+const eof = 0
+
+type ipLex struct {
+	line   []byte
+	peek   rune
+	output Result
+	err    error
+}
+
+func (ip *ipLex) Lex(yylval *ipSymType) int {
+	for {
+		c := ip.next()
+		switch c {
+		case eof:
+			return eof
+		case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
+			return ip.byte(c, yylval)
+		default:
+			return int(c)
+		}
+	}
+}
+
+func (ip *ipLex) byte(c rune, yylval *ipSymType) int {
+	add := func(b *bytes.Buffer, c rune) {
+		if _, err := b.WriteRune(c); err != nil {
+			log.Fatalf("WriteRune: %s", err)
+		}
+	}
+	var b bytes.Buffer
+	add(&b, c)
+L:
+	for {
+		c = ip.next()
+		switch c {
+		case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
+			add(&b, c)
+		default:
+			break L
+		}
+	}
+	if c != eof {
+		ip.peek = c
+	}
+	octet, err := strconv.ParseUint(b.String(), 10, 32)
+	if err != nil {
+		log.Printf("badly formatted octet")
+		return eof
+	}
+	yylval.num = byte(octet)
+	return NUM
+}
+
+func (ip *ipLex) next() rune {
+	if ip.peek != eof {
+		r := ip.peek
+		ip.peek = eof
+		return r
+	}
+	if len(ip.line) == 0 {
+		return eof
+	}
+	c, size := utf8.DecodeRune(ip.line)
+	ip.line = ip.line[size:]
+	if c == utf8.RuneError && size == 1 {
+		log.Print("invalid utf8")
+		return ip.next()
+	}
+	return c
+}
+
+func (ip *ipLex) Error(s string) {
+	ip.err = errors.New(s)
+}

--- a/iprange/lex.go
+++ b/iprange/lex.go
@@ -58,7 +58,7 @@ L:
 		return eof
 	}
 	yylval.num = byte(octet)
-	return NUM
+	return num
 }
 
 func (ip *ipLex) next() rune {

--- a/iprange/sortip.go
+++ b/iprange/sortip.go
@@ -1,0 +1,36 @@
+package iprange
+
+import "net"
+
+// Asc implements sorting in ascending order for IP addresses
+type Asc []net.IP
+
+func (a Asc) Len() int {
+	return len(a)
+}
+
+func (a Asc) Swap(i, j int) {
+	a[i], a[j] = a[j], a[i]
+}
+
+func (a Asc) Less(i, j int) bool {
+	if a[i][0] < a[j][0] {
+		return true
+	}
+
+	if a[i][0] == a[j][0] && a[i][1] < a[j][1] {
+		return true
+	}
+
+	if a[i][0] == a[j][0] && a[i][1] == a[j][1] &&
+		a[i][2] < a[j][2] {
+		return true
+	}
+
+	if a[i][0] == a[j][0] && a[i][1] == a[j][1] &&
+		a[i][2] == a[j][2] && a[i][3] < a[j][3] {
+		return true
+	}
+
+	return false
+}

--- a/iprange/sortip.go
+++ b/iprange/sortip.go
@@ -3,17 +3,17 @@ package iprange
 import "net"
 
 // Asc implements sorting in ascending order for IP addresses
-type Asc []net.IP
+type asc []net.IP
 
-func (a Asc) Len() int {
+func (a asc) Len() int {
 	return len(a)
 }
 
-func (a Asc) Swap(i, j int) {
+func (a asc) Swap(i, j int) {
 	a[i], a[j] = a[j], a[i]
 }
 
-func (a Asc) Less(i, j int) bool {
+func (a asc) Less(i, j int) bool {
 	if a[i][0] < a[j][0] {
 		return true
 	}

--- a/iprange/sortip.go
+++ b/iprange/sortip.go
@@ -1,6 +1,9 @@
 package iprange
 
-import "net"
+import (
+	"math/big"
+	"net"
+)
 
 // Asc implements sorting in ascending order for IP addresses
 type asc []net.IP
@@ -14,23 +17,11 @@ func (a asc) Swap(i, j int) {
 }
 
 func (a asc) Less(i, j int) bool {
-	if a[i][0] < a[j][0] {
+	bigi := big.NewInt(0).SetBytes(a[i])
+	bigj := big.NewInt(0).SetBytes(a[j])
+
+	if bigi.Cmp(bigj) == -1 {
 		return true
 	}
-
-	if a[i][0] == a[j][0] && a[i][1] < a[j][1] {
-		return true
-	}
-
-	if a[i][0] == a[j][0] && a[i][1] == a[j][1] &&
-		a[i][2] < a[j][2] {
-		return true
-	}
-
-	if a[i][0] == a[j][0] && a[i][1] == a[j][1] &&
-		a[i][2] == a[j][2] && a[i][3] < a[j][3] {
-		return true
-	}
-
 	return false
 }

--- a/main.go
+++ b/main.go
@@ -134,6 +134,7 @@ func main() {
 		for {
 			select {
 			case <-c:
+				log.Println("'stop' signal received; stopping...")
 				close(stop)
 				return
 			}

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/binary"
 	"flag"
 	"fmt"
 	"log"
@@ -142,7 +143,7 @@ func main() {
 	go readARP(handler, stop, iface)
 
 	// Get original source
-	origSrc, err := arp.Lookup(hostIP.To4().String())
+	origSrc, err := arp.Lookup(binary.BigEndian.Uint32(hostIP))
 	if err != nil {
 		log.Fatalf("Unable to lookup hw address for %s: %v", hostIP, err)
 	}
@@ -193,7 +194,7 @@ func writeARP(handler *pcap.Handle, stop chan struct{}, targetAddrs []net.IP, sr
 
 				<-t.C
 				for _, ip := range targetAddrs {
-					arpAddr, err := arp.Lookup(ip.String())
+					arpAddr, err := arp.Lookup(binary.BigEndian.Uint32(ip))
 					if err != nil {
 						log.Printf("Could not retrieve %v's MAC address: %v", ip, err)
 						continue


### PR DESCRIPTION
The target parser now supports lists (e.g. `192.168.1.1, 10.10.10.0/24, 1.2.3.4-5`).

TODO:
- Add code to normalize the final, expanded list of targets (remove duplicates, sort, etc.)
