### PR TITLE
Change arp command to ip for the ARPLookup in Linux

### DIFF
--- a/arp/arp_linux.go
+++ b/arp/arp_linux.go
@@ -11,7 +11,7 @@ import (
 	"strconv"
 )
 
-var lineMatch = regexp.MustCompile(`\?\s+\(([0-9\.]+)\)\s+at\s+([0-9a-f:]+).+on\s+([^\s]+)`)
+var lineMatch = regexp.MustCompile(`([0-9\.]+)\s+dev\s+([^\s]+)\s+lladdr\s+([0-9a-f:]+)`)
 
 func hexToInt(h string) uint8 {
 	v, _ := strconv.ParseInt(h, 16, 16)
@@ -23,7 +23,7 @@ func doARPLookup(ip string) (*Address, error) {
 	ping.Run() // TODO: manually inject arp who has packet.
 	ping.Wait()
 
-	cmd := exec.Command("arp", "-an", ip)
+	cmd := exec.Command("ip", "n", "show", ip)
 	out, err := cmd.Output()
 	if err != nil {
 		return nil, errors.New("No entry")
@@ -33,14 +33,14 @@ func doARPLookup(ip string) (*Address, error) {
 	if len(matches) > 0 && len(matches[0]) > 3 {
 		ipAddr := net.ParseIP(matches[0][1])
 
-		macAddrString := matches[0][2]
+		macAddrString := matches[0][3]
 
 		macAddr, err := net.ParseMAC(macAddrString)
 		if err != nil {
 			return nil, fmt.Errorf("ParseMAC: %v", err)
 		}
 
-		iface, err := net.InterfaceByName(matches[0][3])
+		iface, err := net.InterfaceByName(matches[0][2])
 		if err != nil {
 			return nil, fmt.Errorf("InterfaceByName: %v", err)
 		}


### PR DESCRIPTION
Hi @arturovm, please consider this change in order to have a more "portable" method for the lookup in Linux and avoid the installation and usage of the obsolete arp.
 